### PR TITLE
Enhance Travis CI setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,17 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - hhvm
 
 before_script:
-  - wget http://getcomposer.org/composer.phar
-  - php composer.phar install --dev --no-interaction
+  - composer install --no-interaction
  
 script:
   - mkdir -p build/logs
-  - phpunit tests/rapim_tests.php
+  - vendor/bin/phpunit
   
 matrix:
   fast_finish: true
   allow_failures:
       - php: hhvm
-      - php: 7.0
-      - php: 7.1
-      - php: 7.2

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "RAPIM\\": "src/"
+            "RAPIM\\": "tests/"
         }
     },
     "require": {
@@ -39,7 +39,7 @@
         "ext-openssl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.3",
+        "phpunit/phpunit": "^5.0",
         "ext-gmp": "*"
     },
     "suggest": {


### PR DESCRIPTION
# Changed log
- Add `php-7.3` version test because it's stable version.
- The `composer` is included on Travis CI build environment, we don't need to download composer.
- To avoid unexpected pre-build `PHPUnit` version on Travis CI build environment, using the `vendor/bin/phpunit` instead.
- Set the current load test classes automatically inside `autoload-dev` block in `composer.json`.
- To support `php-5.6+` versions, upgrading the `PHPUnit` version to `5.x`.